### PR TITLE
upgrade stack to cflinuxfs3

### DIFF
--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -11,7 +11,7 @@ meta:
     name:   "CI Bot"
 
   buildpack-compile-image:
-    name: cloudfoundry/cflinuxfs2
+    name: cloudfoundry/cflinuxfs3
     tag: latest
 
   cf:

--- a/fixtures/py-sample/app.py
+++ b/fixtures/py-sample/app.py
@@ -8,7 +8,7 @@ import os
 # Initialize the Flask application
 app = Flask(__name__)
 
-# route http posts to this method
+# route http gets to this method
 @app.route('/', methods=['GET'])
 def index():
     return cv2.__version__
@@ -35,5 +35,5 @@ def test():
 
 
 # start flask app
-port = os.getenv('PORT', 5000)
+port = int(os.getenv('PORT', 5000))
 app.run(host="0.0.0.0", port=port)

--- a/fixtures/py-sample/runtime.txt
+++ b/fixtures/py-sample/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.8.1

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,13 +3,13 @@ default_versions:
   version: 3.3.1
 dependencies:
 - cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   md5: eb269dee073ce42979bcf90443980258
   name: opencv
   uri: http://opencv-buildpack.s3-website-us-east-1.amazonaws.com/blobs/opencv/opencv-compiled-3.3.0.tgz
   version: 3.3.0
 - cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   md5: 15076e163f3e8d57d5f4c6b0931e2321
   name: opencv
   uri: http://opencv-buildpack.s3-website-us-east-1.amazonaws.com/blobs/opencv/opencv-compiled-3.3.1.tgz

--- a/packages/opencv/README.md
+++ b/packages/opencv/README.md
@@ -1,4 +1,4 @@
-# Build opencv within cflinuxfs2
+# Build opencv within cflinuxfs3
 
 Our buildpack users will need to download a pre-compiled version of opencv. This Dockerfile describes how to compile opencv and output it as a `tgz` file. Another part of the toolchain will upload the tgz to a public place, from which buildpack users will download it on demand.
 
@@ -15,7 +15,7 @@ docker run -ti \
   -v $PWD/tmp/opencv-output:/opencv-output \
   -e SRC_DIR=/opencv-src \
   -e OUTPUT_DIR=/opencv-output \
-  cloudfoundry/cflinuxfs2 \
+  cloudfoundry/cflinuxfs3 \
   /buildpack/packages/opencv/compile.sh
 ```
 

--- a/packages/opencv/update_manifest.sh
+++ b/packages/opencv/update_manifest.sh
@@ -27,7 +27,7 @@ dependencies:
   version: ${BLOB_NAME}
   uri:     "${DOWNLOAD_ROOT_URL}/blobs/${BLOB_NAME}/$(basename ${BLOB})"
   md5:     "$(md5sum ${BLOB} | awk '{print $1}')"
-  cf_stacks: [cflinuxfs2]
+  cf_stacks: [cflinuxfs3]
 YAML
 
 git clone ${REPO_ROOT} ${REPO_OUT}

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/cutlass/docker.go
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/cutlass/docker.go
@@ -66,8 +66,8 @@ func executeDockerFile(bp_dir, fixture_path, buildpack_path string, envs []strin
 }
 
 func dockerfile(fixture_path, buildpack_path string, envs []string, network_command string) string {
-	out := "FROM cloudfoundry/cflinuxfs2\n" +
-		"ENV CF_STACK cflinuxfs2\n" +
+	out := "FROM cloudfoundry/cflinuxfs3\n" +
+		"ENV CF_STACK cflinuxfs3\n" +
 		"ENV VCAP_APPLICATION {}\n"
 	for _, env := range envs {
 		out = out + "ENV " + env + "\n"

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/fixtures/manifest/fetch/manifest.yml
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/fixtures/manifest/fetch/manifest.yml
@@ -18,67 +18,67 @@ dependencies:
 - name: other_thing
   version: 4.5.6
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/other_thing-4.5.6-linux-x64.tgz
   md5: 7712b658293ea4b2c8505843b0e15441
 - name: thing
   version: 1
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-1-linux-x64.tgz
   md5: 7712b658293ea4b2c8505843b0e15441
 - name: thing
   version: 2
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-2-linux-x64.tgz
   md5: e7437e09b0b13de8cd926e4b9b923fcb
 - name: real_tar_file
   version: 3
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/real_tar_file-3-linux-x64.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
 - name: real_zip_file
   version: 3
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/real_zip_file-3-linux-x64.zip
   md5: 8b9658ba9b7f5a384b40a6d542890541
 - name: thing
   version: 6.2.2
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-6.2.2-linux-x64.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
 - name: thing
   version: 6.2.3
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-6.2.3-linux-x64.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
 - name: thing
   version: 6.2.1
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-6.2.1-linux-x64.tgz
   md5: e7437e09b0b13de8cd926e4b9b923fcb
 - name: thing
   version: 4.6.1
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-4.6.1-linux-x64.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
 - name: thing
   version: 5.2.3
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-5.2.3-linux-x64.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
 - name: nonsemver
   version: 'abc-1.2.3-def-4.5.6'
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/nonsemver-abc-1.2.3-def-4.5.6-linux-x64.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
 - name: godep
@@ -86,4 +86,4 @@ dependencies:
   uri: https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v79-linux-x64-9e37ce0f.tgz
   md5: 2c93222f86668c41ce947d4232e303c2
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/fixtures/manifest/stacks/manifest.yml
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/fixtures/manifest/stacks/manifest.yml
@@ -4,20 +4,20 @@ dependencies:
 - name: other_thing
   version: 4.5.6
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/other_thing-4.5.6-linux-x64.tgz
   md5: 7712b658293ea4b2c8505843b0e15441
 - name: thing
   version: 1
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   - xenial
   uri: https://example.com/dependencies/thing-1-linux-x64.tgz
   md5: 7712b658293ea4b2c8505843b0e15441
 - name: thing
   version: 2
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://example.com/dependencies/thing-2-linux-x64.tgz
   md5: e7437e09b0b13de8cd926e4b9b923fcb
 

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/fixtures/manifest/standard/manifest.yml
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/fixtures/manifest/standard/manifest.yml
@@ -33,49 +33,49 @@ dependencies:
 - name: ruby
   version: 2.2.4
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/libunwind-1.2-linux-x64.tgz
   md5: f56347d4e83c27658a4181ceacd93b35
 - name: ruby
   version: 2.3.3
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/libunwind-1.2-linux-x64.tgz
   md5: f56347d4e83c27658a4181ceacd93b35
 - name: jruby
   version: 9.3.4
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/libunwind-1.2-linux-x64.tgz
   md5: f56347d4e83c27658a4181ceacd93b35
 - name: jruby
   version: 9.3.5
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/libunwind-1.2-linux-x64.tgz
   md5: f56347d4e83c27658a4181ceacd93b35
 - name: jruby
   version: 9.4.4
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/libunwind-1.2-linux-x64.tgz
   md5: f56347d4e83c27658a4181ceacd93b35
 - name: libunwind
   version: 1.2
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/libunwind-1.2-linux-x64.tgz
   md5: f56347d4e83c27658a4181ceacd93b35
 - name: dotnet
   version: 1.0.0-preview2-003156
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet/dotnet.1.0.0-preview2-003156.linux-amd64.tar.gz
   md5: 0afc3d78c0d44e89b01b1eb333824ff5
 - name: dotnet
   version: 1.0.0-preview2-003131
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet/dotnet.1.0.0-preview2-003131.linux-amd64.tar.gz
   md5: ca1ca58a95992c90b0c4230d86168e03
 - name: dotnet
@@ -83,55 +83,55 @@ dependencies:
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet/dotnet.1.0.0-preview2-1-003177.linux-amd64.tar.gz
   md5: 5fd10e42a9fb412a2d25c09fcf14e036
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: dotnet
   version: 1.0.0-preview3-004056
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet/dotnet.1.0.0-preview3-004056.linux-amd64.tar.gz
   md5: f3808b1b6d2d632d6392b1b0f9762e97
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: bower
   version: 1.8.0
   uri: https://buildpacks.cloudfoundry.org/dependencies/bower/bower-1.8.0.tgz
   md5: b61dd4e9685101f82dab8c13b5c085e1
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: dotnet-framework
   version: 1.0.0
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/dotnet-framework.1.0.0.linux-amd64.tar.gz
   md5: 318aba2c18e2bbbc5d0432fd23fc7a8d
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: dotnet-framework
   version: 1.0.1
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/dotnet-framework.1.0.1.linux-amd64.tar.gz
   md5: 249445eb0d92270688d33333f7de4cd0
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: dotnet-framework
   version: 1.0.3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/dotnet-framework.1.0.3.linux-amd64.tar.gz
   md5: cc6bc4bd77c900c3c1f2a3a5ef28e420
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: dotnet-framework
   version: 1.1.0
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/dotnet/dotnet-framework.1.1.0.linux-amd64.tar.gz
   md5: a4fabc3c15c92b795836ad53634cd3dd
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: dotnet
   version: 1.0.0-preview4-004233
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet/dotnet.1.0.0-preview4-004233.linux-amd64.tar.gz
   md5: 30bff5f194e75c4d8e2933c3d50742a6
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 - name: node
   version: 6.9.4
   uri: https://buildpacks.cloudfoundry.org/dependencies/node/node-6.9.4-linux-x64.tgz
   md5: 374ad90048055f1d11bc2ffb70ce08a7
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 exclude_files:
 - ".git/"
 - ".gitignore"

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/manifest_test.go
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/manifest_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Manifest", func() {
 		Context("Stack is supported", func() {
 			BeforeEach(func() {
 				manifestDir = "fixtures/manifest/stacks"
-				err = os.Setenv("CF_STACK", "cflinuxfs2")
+				err = os.Setenv("CF_STACK", "cflinuxfs3")
 				Expect(err).To(BeNil())
 			})
 

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/fixtures/bad/manifest.yml
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/fixtures/bad/manifest.yml
@@ -7,7 +7,7 @@ dependencies:
   md5: fffffff
   uri: https://www.ietf.org/rfc/rfc2324.txt
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 include_files:
 - manifest.yml
 - VERSION

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/fixtures/good/manifest.yml
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/fixtures/good/manifest.yml
@@ -10,7 +10,7 @@ dependencies:
   md5: 84fc21c1adb2f0441c357a943ac464bc
   uri: https://www.ietf.org/rfc/rfc2324.txt
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
 include_files:
 - manifest.yml
 - VERSION

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/fixtures/modules/manifest.yml
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/fixtures/modules/manifest.yml
@@ -6,7 +6,7 @@ dependencies:
   uri: https://buildpacks.cloudfoundry.org/dependencies/php/php-5.6.31-linux-x64-2ed515dd.tgz
   md5: 2ed515dd61fd09206b8f38edf9de6fee
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3
   modules:
   - gearman
   - zlib
@@ -16,4 +16,4 @@ dependencies:
   uri: https://buildpacks.cloudfoundry.org/dependencies/nginx/nginx-1.13.3-linux-x64-53917f43.tgz
   md5: 53917f43684d6ec825ca469ab586c0d2
   cf_stacks:
-  - cflinuxfs2
+  - cflinuxfs3

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/summary_test.go
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/packager/summary_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Packager", func() {
 
 | name | version | cf_stacks |
 |-|-|-|
-| ruby | 1.2.3 | cflinuxfs2 |
+| ruby | 1.2.3 | cflinuxfs3 |
 
 Default binary versions:
 
@@ -53,8 +53,8 @@ Default binary versions:
 
 | name | version | cf_stacks | modules |
 |-|-|-|-|
-| nginx | 1.7.3 | cflinuxfs2 |  |
-| php | 1.6.1 | cflinuxfs2 | gearman, geoip, zlib |
+| nginx | 1.7.3 | cflinuxfs3 |  |
+| php | 1.6.1 | cflinuxfs3 | gearman, geoip, zlib |
 `))
 			})
 		})

--- a/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/stager_test.go
+++ b/src/opencv/vendor/github.com/cloudfoundry/libbuildpack/stager_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Stager", func() {
 	Describe("CheckBuildpackValid", func() {
 		BeforeEach(func() {
 			oldCfStack = os.Getenv("CF_STACK")
-			err = os.Setenv("CF_STACK", "cflinuxfs2")
+			err = os.Setenv("CF_STACK", "cflinuxfs3")
 			Expect(err).To(BeNil())
 		})
 


### PR DESCRIPTION
because `cflinuxfs2` has reached its end of life.

also upgrades to Python 3.8.1 for the sample app.